### PR TITLE
adds error message that indicates repo not found

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31040,6 +31040,9 @@ async function getArtifacts(currentPeriodDays, repo, owner, octokit) {
 
     return artifactsWithUsage(artifacts, startDate, endDate, currentPeriodDays, repo);
   } catch(error) {
+    if (error.message.includes('Not Found')) {
+      throw (new Error(`Repository not found: ${repo}`));
+    }
     throw error;
   }
 }

--- a/spec/repo-artifacts.spec.js
+++ b/spec/repo-artifacts.spec.js
@@ -211,4 +211,17 @@ describe("Repo Artifacts", function() {
 
     expect(caughtError).toEqual(new Error('fetch error'));
   });
+
+  it('handles not found errors', async function() {
+    let caughtError;
+    let octokitTestError = new Moctokit([], true, 'Not Found');
+
+    try {
+      await repoArtifacts.getArtifacts(15, repo, owner, octokitTestError);
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toEqual(new Error('Repository not found: repoA'));
+  });
 });

--- a/src/repo-artifacts.js
+++ b/src/repo-artifacts.js
@@ -30,6 +30,9 @@ async function getArtifacts(currentPeriodDays, repo, owner, octokit) {
 
     return artifactsWithUsage(artifacts, startDate, endDate, currentPeriodDays, repo);
   } catch(error) {
+    if (error.message.includes('Not Found')) {
+      throw (new Error(`Repository not found: ${repo}`));
+    }
     throw error;
   }
 }


### PR DESCRIPTION
This PR:
* adds additional information to the error message when a repo's not found
* originally, the error message just said "Not Found"
* now the error message will include the name of the repo that's not found